### PR TITLE
Additional Sac Bug fix for Bomb Spewer and Dam Builder, Plus Scavenger and Handy fix

### DIFF
--- a/scripts/classes/sigils/Bomb Spewer.gd
+++ b/scripts/classes/sigils/Bomb Spewer.gd
@@ -3,15 +3,14 @@ extends SigilEffect
 # This is called whenever something happens that might trigger a sigil, with 'event' representing what happened
 func handle_event(event: String, params: Array):
 	
-#	print("Bomb Spewer recieved event: ", event, "and friendly = ", isFriendly)
-
 	# attached_card_summoned represents the card bearing the sigil being summoned
 	if event == "card_summoned" and params[0] == card:
-		for cSlot in range(4):
-			if slotManager.is_slot_empty(slotManager.playerSlots[cSlot]):
-				slotManager.summon_card(CardInfo.from_name("Explode Bot"), cSlot, true)
-				print("Summoning boombot into friendly slot ", cSlot)
+		if not "DoublePerish" in card.get_node("AnimationPlayer").current_animation:
+			for cSlot in range(4):
+				if slotManager.is_slot_empty(slotManager.playerSlots[cSlot]):
+					slotManager.summon_card(CardInfo.from_name("Explode Bot"), cSlot, true)
+					print("Summoning boombot into friendly slot ", cSlot)
 				
-			if slotManager.is_slot_empty(slotManager.enemySlots[cSlot]):
-				slotManager.summon_card(CardInfo.from_name("Explode Bot"), cSlot, false)
-				print("Summoning boombot into enemy slot ", cSlot)
+				if slotManager.is_slot_empty(slotManager.enemySlots[cSlot]):
+					slotManager.summon_card(CardInfo.from_name("Explode Bot"), cSlot, false)
+					print("Summoning boombot into enemy slot ", cSlot)

--- a/scripts/classes/sigils/Dam Builder.gd
+++ b/scripts/classes/sigils/Dam Builder.gd
@@ -5,14 +5,15 @@ func handle_event(event: String, params: Array):
 
 	# attached_card_summoned represents the card bearing the sigil being summoned
 	if event == "card_summoned" and params[0] == card:
+		if not "DoublePerish" in card.get_node("AnimationPlayer").current_animation:
 		
-		print("Dam builder triggered!")
+			print("Dam builder triggered!")
 		
-		var cardSlots = slotManager.playerSlots if isFriendly else slotManager.enemySlots
-		var slot = card.slot_idx()
+			var cardSlots = slotManager.playerSlots if isFriendly else slotManager.enemySlots
+			var slot = card.slot_idx()
 		
-		if slot > 0 and slotManager.is_slot_empty(cardSlots[slot - 1]):
-			slotManager.summon_card(CardInfo.from_name("Dam"), slot - 1, isFriendly)
+			if slot > 0 and slotManager.is_slot_empty(cardSlots[slot - 1]):
+				slotManager.summon_card(CardInfo.from_name("Dam"), slot - 1, isFriendly)
 
-		if slot < 3 and slotManager.is_slot_empty(cardSlots[slot + 1]):
-			slotManager.summon_card(CardInfo.from_name("Dam"), slot + 1, isFriendly)
+			if slot < 3 and slotManager.is_slot_empty(cardSlots[slot + 1]):
+				slotManager.summon_card(CardInfo.from_name("Dam"), slot + 1, isFriendly)

--- a/scripts/classes/sigils/Handy.gd
+++ b/scripts/classes/sigils/Handy.gd
@@ -8,9 +8,12 @@ func handle_event(event: String, params: Array):
 		
 		# Discard hand
 		for hCard in fightManager.handManager.get_node("PlayerHand" if isFriendly else "EnemyHand").get_children():
-			hCard.get_node("AnimationPlayer").play("Discard")
+			var Ha =  hCard.get_parent().get_parent().raisedCard if isFriendly else hCard.get_parent().get_parent().opponentRaisedCard
+			if hCard != Ha:
+				hCard.get_node("AnimationPlayer").play("Discard")
 
 		if isFriendly:
+			yield(fightManager.get_tree().create_timer(0.05), "timeout")
 			for _i in range(3):
 				if fightManager.deck.size() == 0:
 					break

--- a/scripts/classes/sigils/Scavenger.gd
+++ b/scripts/classes/sigils/Scavenger.gd
@@ -4,12 +4,22 @@ extends SigilEffect
 func handle_event(event: String, params: Array):
 
 	if event == "card_perished" and not card.in_hand and (params[0].get_parent().get_parent().name == "PlayerSlots") != isFriendly:
-		
-		if isFriendly:
-			fightManager.add_bones(1)
-			if fightManager.opponent_bones > 0:
-				fightManager.add_opponent_bones(-1)
-		else:
-			fightManager.add_opponent_bones(1)
-			if fightManager.bones > 0:
-				fightManager.add_bones(-1)
+		if not params[0].has_sigil("Boneless"):
+			if isFriendly:
+				if params[0].has_sigil("Bone King"):
+					fightManager.add_bones(4)
+					if fightManager.opponent_bones >= 0:
+						fightManager.add_opponent_bones(-4)
+				else: 
+					fightManager.add_bones(1)
+				if fightManager.opponent_bones >= 0:
+					fightManager.add_opponent_bones(-1)
+			else:
+				if params[0].has_sigil("Bone King"):
+					fightManager.add_opponent_bones(4)
+					if fightManager.bones >= 0: 
+						fightManager.add_bones(-4)
+				else:
+					fightManager.add_opponent_bones(1)
+					if fightManager.bones >= 0:
+						fightManager.add_bones(-1)


### PR DESCRIPTION
--Additional Sac Bug fix for Bomb Spewer and Dam Builder--
Added an additional clause for Bomb Spewer and Dam Builder to make it so that Double Death doesn't activate them again while perishing to not be softlocked from playing a blood costing card while sacrificing them while controlling a creature with Double Death. 

--Scavenger Fixes--
Added checks for if the creature that is perishing does not have the Boneless sigil to prevent the Opponent from losing a bone while the player that owns the Scavenger gained a bone despite the creature having the Boneless sigil.

added checks for if the creature perishing has the Bone King sigil so that the player gains all the bones from Bone King and the opponent loses all the Bones awarded from Bone King.

added an equality symbol to the checks for Opponent's bone counter to prevent a previously undiscovered bug that I noticed while testing, the bug was that if multiple creatures were to perish while the opponent had a Scavenger and if the player had no bones before the creatures perished, the player would have 1 Bone not be taken away by the Scavenger.

--Handy Fix for discarding raised card--
added check for if the hCard is raised,  if it isn't then it doesn't discard; before adding the check for if it was raised, it would cause a desync or a softlock because the game would be stuck in 'FORCEPLAY'.