### PR TITLE
Misc-Bug-Fixes

### DIFF
--- a/scripts/CardSlots.gd
+++ b/scripts/CardSlots.gd
@@ -179,7 +179,7 @@ func pre_turn_sigils(friendly: bool):
 			yield (cardAnim, "animation_finished")
 
 		# Dive
-		if card.has_sigil("Waterborne") or card.has_sigil("Tentacle"):
+		if card.get_node("CardBody/DiveOlay").visible:
 			cardAnim.play("UnDive")
 
 			if card.has_sigil("Tentacle"):
@@ -702,12 +702,6 @@ func handle_attack(from_slot, to_slot):
 		if not eCard.has_sigil("Repulsive"):
 			eCard.take_damage(pCard)
 
-		# On kill
-		if eCard.health <= 0:
-			if pCard.has_sigil("Blood Lust"):
-				pCard.card_data.attack += 1
-				pCard.draw_stats()
-
 # Sigil handling
 func get_friendly_cards_sigil(sigil):
 	var found = []
@@ -1018,12 +1012,6 @@ func handle_enemy_attack(from_slot, to_slot):
 
 	else:
 		pCard.take_damage(eCard)
-
-		# On kill
-		if pCard.health <= 0:
-			if eCard.has_sigil("Blood Lust"):
-				eCard.card_data.attack += 1
-				eCard.draw_stats()
 
 # Something for tri strike effect
 remote func set_card_offset(card_slot, offset):

--- a/scripts/classes/cards/PlayingCard.gd
+++ b/scripts/classes/cards/PlayingCard.gd
@@ -425,7 +425,7 @@ func begin_perish(doubleDeath = false):
 
 # This is called when a card evolves with the fledgling sigil
 func evolve():
-
+	var dmgTaken = card_data["health"] - health
 	# Special case: Fledgling 2
 	if has_sigil("Fledgling 2"):
 
@@ -437,9 +437,15 @@ func evolve():
 
 		from_data(card_data)
 
+		health = card_data["health"] - dmgTaken
+
+		for card in slotManager.all_friendly_cards():
+			card.calculate_buffs()
+		for eCard in slotManager.all_enemy_cards():
+			eCard.calculate_buffs()
+
 		return
 
-	var dmgTaken = card_data["health"] - health
 
 	from_data(CardInfo.from_name(card_data["evolution"]))
 

--- a/scripts/classes/sigils/Bellist.gd
+++ b/scripts/classes/sigils/Bellist.gd
@@ -5,40 +5,47 @@ func handle_event(event: String, params: Array):
 
 	# attached_card_summoned represents the card bearing the sigil being summoned
 	if event == "card_summoned" and params[0] == card:
+		if not "DoublePerish" in card.get_node("AnimationPlayer").current_animation:
 		
-		print("Dam builder triggered!")
+			print("Dam builder triggered!")
 		
-		var cardSlots = slotManager.playerSlots if isFriendly else slotManager.enemySlots
-		var slot = card.slot_idx()
+			var cardSlots = slotManager.playerSlots if isFriendly else slotManager.enemySlots
+			var slot = card.slot_idx()
 		
-		if slot > 0 and slotManager.is_slot_empty(cardSlots[slot - 1]):
-			slotManager.summon_card(CardInfo.from_name("Chime"), slot - 1, isFriendly)
+			if slot > 0 and slotManager.is_slot_empty(cardSlots[slot - 1]):
+				slotManager.summon_card(CardInfo.from_name("Chime"), slot - 1, isFriendly)
 
-		if slot < 3 and slotManager.is_slot_empty(cardSlots[slot + 1]):
-			slotManager.summon_card(CardInfo.from_name("Chime"), slot + 1, isFriendly)
+			if slot < 3 and slotManager.is_slot_empty(cardSlots[slot + 1]):
+				slotManager.summon_card(CardInfo.from_name("Chime"), slot + 1, isFriendly)
 	
-	
-	if event == "card_hit" and params[0].card_data.name == "Chime" and params[0].get_parent().get_parent() == card.get_parent().get_parent():
-		print("DDDAAAAAAUUUUUSS")
-#		params[1].take_damage(card, 1)
+	if event == "card_hit" and params[0].card_data.name == "Chime" and params[0].get_parent().get_parent() == card.get_parent().get_parent() \
+	or event == "card_hit" and params[0].card_data.atkspecial == "Bell" and params[0].get_parent().get_parent() == card.get_parent().get_parent():
+		if not params[1].has_sigil("Repulsive"):
+			# Don't Strike dying cards
+			if params[1].get_node("AnimationPlayer").current_animation != "DoublePerish" and params[1].get_node("AnimationPlayer").current_animation != "Perish":
+			
+				print("DDDAAAAAAUUUUUSS")
 
-		# Trigger an attack with the appropriate strike offset
+				# Trigger an attack with the appropriate strike offset
 		
-		# Lower slot to right for attack anim (JANK AF)
-		if card.slot_idx() < 3:
-			card.get_parent().get_parent().get_child(card.slot_idx() + 1).show_behind_parent = true
+				# Lower slot to right for attack anim (JANK AF)
+				if card.slot_idx() < 3:
+					card.get_parent().get_parent().get_child(card.slot_idx() + 1).show_behind_parent = true
 		
-		card.strike_offset = params[1].slot_idx() - card.slot_idx()
+				card.strike_offset = params[1].slot_idx() - card.slot_idx()
 		
-		card.rect_position.x = card.strike_offset * 50
+				card.rect_position.x = card.strike_offset * 50
 		
-		card.get_node("AnimationPlayer").play("Attack")
+				card.get_node("AnimationPlayer").play("Attack")
 		
-		yield(card.get_node("AnimationPlayer"), "animation_finished")
+				yield(card.get_node("AnimationPlayer"), "animation_finished")
 		
-		card.strike_offset = 0
-		card.rect_position.x = card.strike_offset * 50
+				card.strike_offset = 0
+				card.rect_position.x = card.strike_offset * 50
 		
-		if card.slot_idx() < 3:
-			card.get_parent().get_parent().get_child(card.slot_idx() + 1).show_behind_parent = false
+				if card.slot_idx() < 3:
+					card.get_parent().get_parent().get_child(card.slot_idx() + 1).show_behind_parent = false
 		
+				if card.health <= 0:
+					card.get_node("AnimationPlayer").play("Perish")
+			

--- a/scripts/classes/sigils/Blood Lust.gd
+++ b/scripts/classes/sigils/Blood Lust.gd
@@ -1,0 +1,10 @@
+extends SigilEffect
+
+# This is called whenever something happens that might trigger a sigil, with 'event' representing what happened
+func handle_event(event: String, params: Array):
+
+	# Did this card just get hit?
+	if event == "card_hit" and params[1] == card and params[0].get_node("AnimationPlayer").current_animation == "Perish":
+		if params[1].get_node("AnimationPlayer").current_animation == "Attack":
+			card.card_data.attack += 1
+			card.draw_stats()

--- a/scripts/classes/sigils/Sentry.gd
+++ b/scripts/classes/sigils/Sentry.gd
@@ -12,12 +12,14 @@ func handle_event(event: String, params: Array):
 			if params[0].get_node("AnimationPlayer").current_animation == "DoublePerish":
 				return
 				
-			# If I'm moving, hit 'em where it hurts
-			if params[0] == card and event == "card_moved":
-				hit_and_run(params)
-			else:
-				normal_behaviour(params)
-	
+			# Cannot see if dead or double dead
+			if card.get_node("AnimationPlayer").current_animation != "Perish" \
+			and card.get_node("AnimationPlayer").current_animation != "DoublePerish":
+				
+				if params[0] == card and event == "card_moved":
+					hit_and_run(params)
+				else:
+					normal_behaviour(params)
 
 func normal_behaviour(params: Array):
 	# Target card must be in opposing spaces


### PR DESCRIPTION
--Waterborne--
originally only checked for if the creature has Waterborne or Tentacle Waterborne, this would cause problems because  if a creature evolved into something without either of those it would remain Submerged; now it checks for it's submerged to unsubmerge

--Fledgling 2--
originally didn't have the damage taken variable so it wouldn't subtract the damage taken when it partially evolved, also added a buff recalculation for it to not temporarily ignore any buffs

--Bellist--
Added a clause that prevents the Chime building part from activating from Double Death to prevent softlocks.
Added an additional check for the retaliation part for if the card has the Bell Atk Special.
Added a check for if the attacking creature has Repulsive to not Strike it,
and added a check for if the attacking creature for if the attacking creature is dying or double dying to not strike the opponent's face. the only bug left to fix for Bellist is that Strafe Sigils do not yield for Bellist and cause it to strike face

--Blood Lust--
Made it not hard coded, also there was a bug where it only increased the creature's power when the defending creature had 0 or less health, not when it died

--Sentry--
Added a check for if the Sentry is dying or double dying to not see the spawned in creature from Shed
