### PR TITLE
fixed Handy + customisable candle snuffing

### DIFF
--- a/packed/RulesetEditor.tscn
+++ b/packed/RulesetEditor.tscn
@@ -124,15 +124,31 @@ value = 1.0
 
 [node name="SnuffLabel" type="Label" parent="Cards/Panel/Options"]
 margin_top = 45.0
-margin_right = 219.0
+margin_right = 244.0
 margin_bottom = 69.0
-text = "Allow snuffing candles for Greater Smoke: "
+rect_pivot_offset = Vector2( -328, 229 )
+text = "Allow snuffing candles"
 
 [node name="allow_snuffing_candles" type="CheckBox" parent="Cards/Panel/Options"]
-margin_left = 473.0
+margin_left = 255.0
+margin_top = 42.0
+margin_right = 275.0
+margin_bottom = 76.0
+
+[node name="SnuffForLabel" type="Label" parent="Cards/Panel/Options"]
+margin_left = 286.0
 margin_top = 45.0
-margin_right = 493.0
-margin_bottom = 79.0
+margin_right = 598.0
+margin_bottom = 69.0
+rect_pivot_offset = Vector2( -328, 229 )
+text = "for (default Greater Smoke)"
+
+[node name="snuff_card" type="LineEdit" parent="Cards/Panel/Options"]
+margin_left = 603.0
+margin_top = 43.0
+margin_right = 935.0
+margin_bottom = 71.0
+placeholder_text = "Greater Smoke"
 
 [node name="HPTLabel" type="Label" parent="Cards/Panel/Options"]
 margin_top = 85.0

--- a/scripts/CardSlots.gd
+++ b/scripts/CardSlots.gd
@@ -1050,8 +1050,23 @@ func _on_Snuff_pressed():
 	if fightManager.lives > 1 and CardInfo.all_data.allow_snuffing_candles:
 		fightManager.inflict_damage(-10)
 		fightManager.damage_stun = false
-		fightManager.draw_card(CardInfo.from_name("Greater Smoke"))
-
+		
+		var snuffCardData = null
+		if "snuff_card" in CardInfo.all_data:
+			snuffCardData = CardInfo.from_name(CardInfo.all_data.snuff_card)
+		
+		if snuffCardData == null:
+			snuffCardData = {
+				"name": "Greater Smoke",
+				"sigils": ["Bone King"],
+				"attack": 1,
+				"health": 3,
+				"banned": true,
+				"rare": true,
+				"description": "Ported from Act 1. Act 2 sprite by syntaxevasion."
+			}
+		fightManager.draw_card(snuffCardData)
+		
 		fightManager.send_move({
 			"type": "snuff_candle"
 		})

--- a/scripts/UI/RulesetEditor.gd
+++ b/scripts/UI/RulesetEditor.gd
@@ -384,47 +384,49 @@ func load_pixport():
 func update_flags():
 	CardInfo.all_data.num_candles = flagDats[1].value
 	CardInfo.all_data.allow_snuffing_candles = flagDats[3].pressed
-	CardInfo.all_data.hammers_per_turn = flagDats[5].value
-	CardInfo.all_data.deck_size_min = flagDats[7].value
-	CardInfo.all_data.max_commons_main = flagDats[9].value
-	CardInfo.all_data.max_commons_side = flagDats[11].value
-	CardInfo.all_data.variable_attack_nerf = flagDats[13].pressed
+	CardInfo.all_data.snuff_card = flagDats[5].text
+	CardInfo.all_data.hammers_per_turn = flagDats[7].value
+	CardInfo.all_data.deck_size_min = flagDats[9].value
+	CardInfo.all_data.max_commons_main = flagDats[11].value
+	CardInfo.all_data.max_commons_side = flagDats[13].value
+	CardInfo.all_data.variable_attack_nerf = flagDats[15].pressed
 	
 	if flagDats[15].pressed:
 		CardInfo.all_data.necro_boned = true
 	else:
 		CardInfo.all_data.erase("necro_boned")
-	CardInfo.all_data.ant_limit = flagDats[17].value
-	CardInfo.all_data.description = flagDats[18].text
-	CardInfo.all_data.portrait = flagDats[20].text
+	CardInfo.all_data.ant_limit = flagDats[19].value
+	CardInfo.all_data.description = flagDats[20].text
+	CardInfo.all_data.portrait = flagDats[22].text
 	
-	if flagDats[23].value != 0:
-		CardInfo.all_data.starting_bones = flagDats[23].value
+	if flagDats[25].value != 0:
+		CardInfo.all_data.starting_bones = flagDats[25].value
 	else:
 		CardInfo.all_data.erase("starting_bones")
 		
-	if flagDats[25].value != 0:
-		CardInfo.all_data.starting_energy_max = flagDats[25].value
+	if flagDats[27].value != 0:
+		CardInfo.all_data.starting_energy_max = flagDats[27].value
 	else:
 		CardInfo.all_data.erase("starting_energy_max")
 
 func populate_flags():
 	flagDats[1].value = CardInfo.all_data.num_candles
 	flagDats[3].pressed = CardInfo.all_data.allow_snuffing_candles
-	flagDats[5].value = CardInfo.all_data.hammers_per_turn
-	flagDats[7].value = CardInfo.all_data.deck_size_min
-	flagDats[9].value = CardInfo.all_data.max_commons_main
-	flagDats[11].value = CardInfo.all_data.max_commons_side
-	flagDats[13].pressed = CardInfo.all_data.variable_attack_nerf
-	flagDats[15].pressed = "necro_boned" in CardInfo.all_data
-	flagDats[17].value = CardInfo.all_data.ant_limit
-	flagDats[18].text = CardInfo.all_data.description
+	flagDats[5].text = CardInfo.all_data.snuff_card if "snuff_card" in CardInfo.all_data else ""
+	flagDats[7].value = CardInfo.all_data.hammers_per_turn
+	flagDats[9].value = CardInfo.all_data.deck_size_min
+	flagDats[11].value = CardInfo.all_data.max_commons_main
+	flagDats[13].value = CardInfo.all_data.max_commons_side
+	flagDats[15].pressed = CardInfo.all_data.variable_attack_nerf
+	flagDats[17].pressed = "necro_boned" in CardInfo.all_data
+	flagDats[19].value = CardInfo.all_data.ant_limit
+	flagDats[20].text = CardInfo.all_data.description
 	
 	if "starting_bones" in CardInfo.all_data:
-		flagDats[23].value = CardInfo.all_data.starting_bones
+		flagDats[25].value = CardInfo.all_data.starting_bones
 	
 	if "starting_energy_max" in CardInfo.all_data:
-		flagDats[25].value = CardInfo.all_data.starting_energy_max
+		flagDats[27].value = CardInfo.all_data.starting_energy_max
 	
 	
 	
@@ -439,10 +441,10 @@ func populate_flags():
 	while file_name != "":
 		
 		if file_name.ends_with(".png"):
-			flagDats[20].add_item("portraits/" + file_name.split(".png")[0])
+			flagDats[22].add_item("portraits/" + file_name.split(".png")[0])
 			
-			if flagDats[20].get_item_text(idx) == CardInfo.all_data.portrait:
-				flagDats[20].select(idx)
+			if flagDats[22].get_item_text(idx) == CardInfo.all_data.portrait:
+				flagDats[22].select(idx)
 			
 			idx += 1
 			

--- a/scripts/classes/sigils/Handy.gd
+++ b/scripts/classes/sigils/Handy.gd
@@ -14,7 +14,19 @@ func handle_event(event: String, params: Array):
 
 		if isFriendly:
 			yield(fightManager.get_tree().create_timer(0.05), "timeout")
-			for _i in range(3):
+			
+			var mainDeckCards
+			if fightManager.side_deck.size() == 0:
+				mainDeckCards = 4
+			else:
+				mainDeckCards = 3
+				
+				fightManager.draw_card(fightManager.side_deck.pop_front(), fightManager.get_node("DrawPiles/YourDecks/SideDeck"))
+
+				if fightManager.side_deck.size() == 0:
+					fightManager.get_node("DrawPiles/YourDecks/SideDeck").visible = false
+		
+			for _i in range(mainDeckCards):
 				if fightManager.deck.size() == 0:
 					break
 				
@@ -24,8 +36,3 @@ func handle_event(event: String, params: Array):
 				if fightManager.deck.size() == 0:
 					fightManager.get_node("DrawPiles/YourDecks/Deck").visible = false
 					break
-				
-			fightManager.draw_card(fightManager.side_deck.pop_front(), fightManager.get_node("DrawPiles/YourDecks/SideDeck"))
-
-			if fightManager.side_deck.size() == 0:
-				fightManager.get_node("DrawPiles/YourDecks/SideDeck").visible = false


### PR DESCRIPTION
- Handy will no longer crash the game when side deck is empty or disabled, and will instead attempt to draw the fourth card from main deck
- As well as `allow_candle_snuffing`, rulesets may also have a `snuff_card` rule to specify a card other than Greater Smoke to get from snuffing candles
- The game will no longer crash when attempting to snuff a candle for an undefined card, and will instead give Greater Smoke
- Updated the built-in ruleset editor to reflect the new `snuff_card` rule