### PR TITLE
Have stinkbug tell you when the tunnel is down

### DIFF
--- a/NewMain.tscn
+++ b/NewMain.tscn
@@ -465,6 +465,8 @@ autowrap = true
 
 [node name="HTTPRequest" type="HTTPRequest" parent="TitleScreen/PullInfo"]
 
+[node name="TunnelRequest" type="HTTPRequest" parent="TitleScreen/PullInfo"]
+
 [node name="Blocker" type="Panel" parent="TitleScreen"]
 visible = false
 anchor_right = 1.0
@@ -1282,6 +1284,7 @@ mouse_filter = 2
 [connection signal="pressed" from="TitleScreen/Menu/VBoxContainer/DiscordBtn" to="TitleScreen" method="_on_DiscordBtn_pressed"]
 [connection signal="pressed" from="TitleScreen/PullInfo/PatchStoats/Notes/Button" to="TitleScreen/PullInfo" method="_on_Button_pressed"]
 [connection signal="request_completed" from="TitleScreen/PullInfo/HTTPRequest" to="TitleScreen/PullInfo" method="_on_HTTPRequest_request_completed"]
+[connection signal="request_completed" from="TitleScreen/PullInfo/TunnelRequest" to="TitleScreen/PullInfo" method="_on_TunnelRequest_request_completed"]
 [connection signal="item_selected" from="TitleScreen/LobbyHost/Rows/HostType/Type" to="TitleScreen" method="_on_HostType_selected"]
 [connection signal="focus_entered" from="TitleScreen/LobbyHost/Rows/Roomname/LineEdit" to="TitleScreen" method="_LineEdit_focused"]
 [connection signal="focus_exited" from="TitleScreen/LobbyHost/Rows/Roomname/LineEdit" to="TitleScreen" method="_LineEdit_unfocused"]

--- a/project.godot
+++ b/project.godot
@@ -20,6 +20,11 @@ _global_script_classes=[ {
 "path": "res://scripts/classes/cards/CardData.gd"
 }, {
 "base": "Reference",
+"class": "Deck",
+"language": "GDScript",
+"path": "res://scripts/structs/Deck.gd"
+}, {
+"base": "Reference",
 "class": "Replay",
 "language": "GDScript",
 "path": "res://scripts/classes/Replay.gd"
@@ -32,6 +37,7 @@ _global_script_classes=[ {
 _global_script_class_icons={
 "BuffEffect": "",
 "Card": "",
+"Deck": "",
 "Replay": "",
 "SigilEffect": ""
 }

--- a/scripts/PullInfo.gd
+++ b/scripts/PullInfo.gd
@@ -12,7 +12,6 @@ func _ready():
 		return
 		
 	$HTTPRequest.request("https://raw.githubusercontent.com/107zxz/inscr-onln-ruleset/main/motd.json")
-	
 
 func _on_HTTPRequest_request_completed(_result, response_code, _headers, body):
 	if response_code == 200:
@@ -40,7 +39,15 @@ func _on_HTTPRequest_request_completed(_result, response_code, _headers, body):
 		if res.motd_grimorger != "":
 			$Grimorger.visible = true
 			$Grimorger/Notes.text = res.motd_grimorger
+		else:
+			$TunnelRequest.request("http://localtunnel.me")
 
 func _on_Button_pressed():
 #	OS.shell_open("https://107zxz.itch.io/inscryption-multiplayer-godot")
 	get_tree().change_scene("res://packed/GameUpdater.tscn")
+
+
+func _on_TunnelRequest_request_completed(result, response_code, headers, body):
+	if response_code != 200:
+		$Grimorger.visible = true
+		$Grimorger/Notes.text = "The tunnel is down! Room code lobbies won't work!"


### PR DESCRIPTION
Extra HTTP request when querying stoat / stinkbug text to inform of tunnel outages. Is overridden by ARG messages when relevant.

<img width="952" alt="Screenshot 2025-04-08 at 09 21 27" src="https://github.com/user-attachments/assets/ac22c7c8-8028-456f-9052-b1b78eb8866e" />