### PR TITLE
Gem Detonator (5) and Gem Dependant fix

### DIFF
--- a/scripts/CardFight.gd
+++ b/scripts/CardFight.gd
@@ -1206,8 +1206,11 @@ func start_turn():
 	# Gold sarcophagus
 	for pharoah in gold_sarcophagus:
 		if pharoah.turnsleft <= 0:
-			draw_card(pharoah.card)
-			gold_sarcophagus.erase(pharoah.card)
+			if pharoah.turnsleft < 0: 
+				gold_sarcophagus.erase(pharoah)
+			else:
+				draw_card(pharoah.card)
+				pharoah.turnsleft -= 1
 		else:
 			pharoah.turnsleft -= 1
 	

--- a/scripts/CardSlots.gd
+++ b/scripts/CardSlots.gd
@@ -12,7 +12,7 @@ onready var nLanes = CardInfo.all_data.lanes
 onready var lastLane = CardInfo.all_data.last_lane
 
 # Cards selected for sacrifice
-var sacVictims = []
+var sac_victims = []
 
 func _ready():
 	var slotGroups = [$PlayerSlots, $PlayerSlotsBack, $EnemySlots, $EnemySlotsBack]
@@ -107,17 +107,17 @@ func is_cat_bricked() -> bool:
 	return true
 
 func clear_sacrifices():
-	for victim in sacVictims:
+	for victim in sac_victims:
 		victim.get_node("CardBody/SacOlay").visible = false
 		rpc_id(fightManager.opponent, "set_sac_olay_vis", victim.get_parent().get_position_in_parent(), false)
 
-	sacVictims.clear()
+	sac_victims.clear()
 
 func attempt_sacrifice():
 
 	var sacValue = 0
 
-	for victim in sacVictims:
+	for victim in sac_victims:
 		sacValue += victim.calc_blood()
 #		if victim.has_sigil("Worthy Sacrifice"):
 #			sacValue += 2
@@ -130,7 +130,7 @@ func attempt_sacrifice():
 		if not get_available_slots():
 			print("Checking for catbrick...")
 			var bricked = true
-			for v in sacVictims:
+			for v in sac_victims:
 				if v.has_sigil("Many Lives") or v.has_sigil("Frozen Away") or v.has_sigil("Ruby Heart"):
 					continue
 				bricked = false
@@ -140,7 +140,7 @@ func attempt_sacrifice():
 				return
 		
 		# Kill sacrifical victims
-		for victim in sacVictims:
+		for victim in sac_victims:
 			if victim.has_sigil("Many Lives"):
 				victim.get_node("AnimationPlayer").play("CatSac")
 #				rpc_id(fightManager.opponent, "remote_card_anim", victim.slot_idx(), "CatSac")
@@ -173,7 +173,7 @@ func attempt_sacrifice():
 				})
 
 
-		sacVictims.clear()
+		sac_victims.clear()
 
 		# Force player to summon the new card
 		if get_available_slots():

--- a/scripts/classes/sigils/Gem Dependant.gd
+++ b/scripts/classes/sigils/Gem Dependant.gd
@@ -1,17 +1,21 @@
 extends SigilEffect
 
+func start_of_turn(cardAnim):
+	Gem_Dep()
+	
 # This is called whenever something happens that might trigger a sigil, with 'event' representing what happened
 func handle_event(event: String, params: Array):
 
-	# Don't die in hand
-	if card.get_parent().name == "PlayerHand":
-		return
-
 	# attached_card_summoned represents the card bearing the sigil being summoned
-	if (event == "card_summoned" and params[0] == card) or (event == "card_perished" and params[0] != card):
+	# Left side is checking when the card is played, Right side is checking when anything perishes
+	if (event == "card_summoned" and params[0] == card and not card.in_hand) or (event == "card_perished" and params[0] != card and not card.in_hand and CardInfo.all_data.vanilla_gem_dep != true):
+			Gem_Dep()
 
-		# Die if no gems
-		if not "Perish" in card.get_node("AnimationPlayer").current_animation:
+func end_of_turn(cardAnim):
+	Gem_Dep()
+	
+func Gem_Dep():
+	if not "Perish" in card.get_node("AnimationPlayer").current_animation:
 
 			var kill = not (slotManager.get_friendly_cards_sigil("Great Mox") if is_friendly else slotManager.get_enemy_cards_sigil("Great Mox"))
 
@@ -24,4 +28,4 @@ func handle_event(event: String, params: Array):
 			if kill:
 				print("Gem dependant card should die!")
 				card.get_node("AnimationPlayer").play("Perish")
-		
+				

--- a/scripts/classes/sigils/Gem Detonator (5).gd
+++ b/scripts/classes/sigils/Gem Detonator (5).gd
@@ -8,9 +8,6 @@ func handle_event(event: String, params: Array):
 
 	if card.get_parent().get_parent() != params[0].get_parent().get_parent():
 		return
-		
-	if params[0] == card:
-		return
 	
 	if not "Mox" in params[0].card_data.name:
 		return


### PR DESCRIPTION
Fixes Gem Detonator (5) to count itself, as requested by SylveonM45T3R.

Adds customization to Gem Dep to work how it does in base game.

adds new bool to the JSON called: `vanilla_gem_dep`

It's only used for disabling the death trigger of Gem Dep to make it able to be checked at the end or start of turn.