### PR TITLE
Fixed sac_victims and Reconstitute + other stuff

### DIFF
--- a/scripts/CardFight.gd
+++ b/scripts/CardFight.gd
@@ -672,7 +672,7 @@ func card_summoned(playedCard):
 #		eCard.calculate_buffs()
 
 	# Starvation, inflict damage if 9th onwards
-	if playedCard.card_data["name"] == "Starvation" and playedCard.attack >= 9:
+	if playedCard.card_data["name"] == CardInfo.all_cards[0]["name"] and playedCard.attack >= 9:
 		# Ramp damage over time so the game actually ends
 		inflict_damage(playedCard.attack - 8)
 	
@@ -889,7 +889,7 @@ func _opponent_played_card(card, slot, ignore_cost = false):
 	var card_dt = card if typeof(card) == TYPE_DICTIONARY else CardInfo.all_cards[card]
 	
 	# Special case: Starvation
-	if card_dt["name"] == "Starvation":
+	if card_dt["name"] == CardInfo.all_cards[0]["name"]:
 		
 		# Inflict starve damage
 		if turns_starving >= 9:
@@ -934,7 +934,7 @@ func _opponent_played_card_back(card, slot, ignore_cost = false):
 	var card_dt = card if typeof(card) == TYPE_DICTIONARY else CardInfo.all_cards[card]
 	
 	# Special case: Starvation
-#	if card_dt["name"] == "Starvation":
+#	if card_dt["name"] == CardInfo.all_cards[0]["name"]:
 #
 #		# Inflict starve damage
 #		if turns_starving >= 9:
@@ -986,8 +986,8 @@ remote func force_draw_starv(strength):
 	
 	var starv_data = CardInfo.all_cards[0].duplicate()
 	starv_data["attack"] = strength
-	if strength >= 5:
-		starv_data["sigils"] = ["Repulsive", "Mighty Leap"]
+	if strength >= 5 and not starv_data["sigils"].has("Mighty Leap"):
+		starv_data["sigils"].append("Mighty Leap")
 	
 	starv_card.from_data(starv_data)
 	
@@ -1207,7 +1207,7 @@ func start_turn():
 	for pharoah in gold_sarcophagus:
 		if pharoah.turnsleft <= 0:
 			draw_card(pharoah.card)
-			gold_sarcophagus.erase(pharoah.card)
+			gold_sarcophagus.erase(pharoah)
 		else:
 			pharoah.turnsleft -= 1
 	

--- a/scripts/CardFight.gd
+++ b/scripts/CardFight.gd
@@ -672,7 +672,7 @@ func card_summoned(playedCard):
 #		eCard.calculate_buffs()
 
 	# Starvation, inflict damage if 9th onwards
-	if playedCard.card_data["name"] == CardInfo.all_cards[0]["name"] and playedCard.attack >= 9:
+	if playedCard.card_data["name"] == get_starv_name() and playedCard.attack >= 9:
 		# Ramp damage over time so the game actually ends
 		inflict_damage(playedCard.attack - 8)
 	
@@ -889,7 +889,7 @@ func _opponent_played_card(card, slot, ignore_cost = false):
 	var card_dt = card if typeof(card) == TYPE_DICTIONARY else CardInfo.all_cards[card]
 	
 	# Special case: Starvation
-	if card_dt["name"] == CardInfo.all_cards[0]["name"]:
+	if card_dt["name"] == get_starv_name():
 		
 		# Inflict starve damage
 		if turns_starving >= 9:
@@ -934,7 +934,7 @@ func _opponent_played_card_back(card, slot, ignore_cost = false):
 	var card_dt = card if typeof(card) == TYPE_DICTIONARY else CardInfo.all_cards[card]
 	
 	# Special case: Starvation
-#	if card_dt["name"] == CardInfo.all_cards[0]["name"]:
+#	if card_dt["name"] == get_starv_name():
 #
 #		# Inflict starve damage
 #		if turns_starving >= 9:
@@ -981,17 +981,22 @@ remote func force_draw_starv(strength):
 	if $MoonFight/BothMoons/FriendlyMoon.visible:
 		$MoonFight/BothMoons/FriendlyMoon.attack += 1
 		$MoonFight/BothMoons/FriendlyMoon.update_stats()
-
-	var starv_card = draw_card(0, $DrawPiles/YourDecks/Deck, false)
 	
-	var starv_data = CardInfo.all_cards[0].duplicate()
+	var starv_card = draw_card(get_starv_name(), $DrawPiles/YourDecks/Deck, false)
+	# new_card.from_data(CardInfo.from_name(card))
+	var starv_data = CardInfo.from_name(get_starv_name()).duplicate()
 	starv_data["attack"] = strength
 	if strength >= 5 and not starv_data["sigils"].has("Mighty Leap"):
 		starv_data["sigils"].append("Mighty Leap")
-	
 	starv_card.from_data(starv_data)
 	
 	move_done()
+
+func get_starv_name():
+	for card in CardInfo.all_cards:
+		if card["name"] == "Starvation":
+			return "Starvation"
+	return CardInfo.all_cards[0]["name"]
 
 # Called during attack animation
 func inflict_damage(dmg):

--- a/scripts/CardSlots.gd
+++ b/scripts/CardSlots.gd
@@ -12,7 +12,7 @@ onready var nLanes = CardInfo.all_data.lanes
 onready var lastLane = CardInfo.all_data.last_lane
 
 # Cards selected for sacrifice
-var sacVictims = []
+var sac_victims = []
 
 func _ready():
 	var slotGroups = [$PlayerSlots, $PlayerSlotsBack, $EnemySlots, $EnemySlotsBack]
@@ -107,17 +107,17 @@ func is_cat_bricked() -> bool:
 	return true
 
 func clear_sacrifices():
-	for victim in sacVictims:
+	for victim in sac_victims:
 		victim.get_node("CardBody/SacOlay").visible = false
 		rpc_id(fightManager.opponent, "set_sac_olay_vis", victim.get_parent().get_position_in_parent(), false)
 
-	sacVictims.clear()
+	sac_victims.clear()
 
 func attempt_sacrifice():
 
 	var sacValue = 0
 
-	for victim in sacVictims:
+	for victim in sac_victims:
 		sacValue += victim.calc_blood()
 #		if victim.has_sigil("Worthy Sacrifice"):
 #			sacValue += 2
@@ -130,7 +130,7 @@ func attempt_sacrifice():
 		if not get_available_slots():
 			print("Checking for catbrick...")
 			var bricked = true
-			for v in sacVictims:
+			for v in sac_victims:
 				if v.has_sigil("Many Lives") or v.has_sigil("Frozen Away") or v.has_sigil("Ruby Heart"):
 					continue
 				bricked = false
@@ -140,7 +140,7 @@ func attempt_sacrifice():
 				return
 		
 		# Kill sacrifical victims
-		for victim in sacVictims:
+		for victim in sac_victims:
 			if victim.has_sigil("Many Lives"):
 				victim.get_node("AnimationPlayer").play("CatSac")
 #				rpc_id(fightManager.opponent, "remote_card_anim", victim.slot_idx(), "CatSac")
@@ -173,7 +173,7 @@ func attempt_sacrifice():
 				})
 
 
-		sacVictims.clear()
+		sac_victims.clear()
 
 		# Force player to summon the new card
 		if get_available_slots():

--- a/scripts/classes/sigils/Bomb Latch.gd
+++ b/scripts/classes/sigils/Bomb Latch.gd
@@ -52,10 +52,9 @@ func handle_event(event: String, params: Array):
 		if "sigils" in target.card_data:
 			# Deep copy sigil array
 			var n_sigils = target.card_data.sigils.duplicate()
-			if "Detonator" in n_sigils:
-				n_sigils.erase("Detonator")
-			n_sigils.append("Detonator")
-			target.card_data.sigils = n_sigils
+			if not "Detonator" in n_sigils:
+				n_sigils.append("Detonator")
+				target.card_data.sigils = n_sigils
 		else:
 			target.card_data.sigils = ["Detonator"]
 		

--- a/scripts/classes/sigils/Bomb Latch.gd
+++ b/scripts/classes/sigils/Bomb Latch.gd
@@ -52,6 +52,8 @@ func handle_event(event: String, params: Array):
 		if "sigils" in target.card_data:
 			# Deep copy sigil array
 			var n_sigils = target.card_data.sigils.duplicate()
+			if "Detonator" in n_sigils:
+				n_sigils.erase("Detonator")
 			n_sigils.append("Detonator")
 			target.card_data.sigils = n_sigils
 		else:

--- a/scripts/classes/sigils/Brittle Latch.gd
+++ b/scripts/classes/sigils/Brittle Latch.gd
@@ -59,10 +59,9 @@ func handle_event(event: String, params: Array):
 		if "sigils" in target.card_data:
 			# Deep copy sigil array
 			var n_sigils = target.card_data.sigils.duplicate()
-			if "Brittle" in n_sigils:
-				n_sigils.erase("Brittle")
-			n_sigils.append("Brittle")
-			target.card_data.sigils = n_sigils
+			if not "Brittle" in n_sigils:
+				n_sigils.append("Brittle")
+				target.card_data.sigils = n_sigils
 		else:
 			target.card_data.sigils = ["Brittle"]
 		

--- a/scripts/classes/sigils/Brittle Latch.gd
+++ b/scripts/classes/sigils/Brittle Latch.gd
@@ -59,6 +59,8 @@ func handle_event(event: String, params: Array):
 		if "sigils" in target.card_data:
 			# Deep copy sigil array
 			var n_sigils = target.card_data.sigils.duplicate()
+			if "Brittle" in n_sigils:
+				n_sigils.erase("Brittle")
 			n_sigils.append("Brittle")
 			target.card_data.sigils = n_sigils
 		else:

--- a/scripts/classes/sigils/Gem Guardian.gd
+++ b/scripts/classes/sigils/Gem Guardian.gd
@@ -14,6 +14,8 @@ func handle_event(event: String, params: Array):
 				if "sigils" in card2.card_data:
 				# Deep copy sigil array
 					var n_sigils = card2.card_data.sigils.duplicate()
+					if "Armored" in n_sigils:
+						n_sigils.erase("Armored")
 					n_sigils.append("Armored")
 					card2.card_data.sigils = n_sigils
 				else:
@@ -21,6 +23,6 @@ func handle_event(event: String, params: Array):
 					
 				var old_atk = card2.attack
 				var old_hp = card2.health
-				card2.from_data(card.card_data)
+				card2.from_data(card2.card_data)
 				card2.attack = old_atk
 				card2.health = old_hp

--- a/scripts/classes/sigils/Shield Latch.gd
+++ b/scripts/classes/sigils/Shield Latch.gd
@@ -54,6 +54,8 @@ func handle_event(event: String, params: Array):
 		if "sigils" in target.card_data:
 			# Deep copy sigil array
 			var n_sigils = target.card_data.sigils.duplicate()
+			if "Armored" in n_sigils:
+				n_sigils.erase("Armored")
 			n_sigils.append("Armored")
 			target.card_data.sigils = n_sigils
 		else:


### PR DESCRIPTION
- Fixed `sac_victims` not being renamed in CardSlots.gd
- Fixed cards with Reconstitute coming back every turn instead of only once.
- ~~Starve damage uses the first card in the Ruleset instead of `"Starvation"` explicitly.~~ Starve damage uses the first card in the Ruleset if no card named `"Starvation"` exists in the Ruleset.
- Starvation properties are given to the first card in the Ruleset if no card in the Ruleset is named `"Starvation"`
- Unhardcoded 5+ attack Starvation cards' sigils. (now *appends* `"Mighty Leap"` instead being *set* to `["Repulsive", "Mighty Leap"]`)
- Shield Latch and Gem Guardian now removes Armored if the target already has Armored, before adding Armored. (to prevent repeated latching from adding too many sigils) [(Thanks Amelia.)](https://media.discordapp.net/attachments/1287954220313481216/1368068771817717760/image.png?ex=68cd7894&is=68cc2714&hm=ce630032a43f2c7ba7f0fa1d6a12874fa62fb088c0979c7548cd04e289fa0be7&=&format=webp&quality=lossless)
- Brittle/Bomb Latch now doesn't add Brittle/Detonator if the target already has that sigil. (again, to prevent repeated latching from adding too many sigils)